### PR TITLE
Remove time import

### DIFF
--- a/optional.go
+++ b/optional.go
@@ -4,10 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"time"
 )
-
-var _ = time.Time{}
 
 type Optional[T any] optional[T]
 


### PR DESCRIPTION
### What
Remove time import.

### Why
It is not used. The time import existed to make sure time was present for the generated time code. This is now unnecessary with the use of generics.