### PR TITLE
Run go fmt with Go 1.21rc2

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@ Package optional exports an Optional[T] type that can wrap any type to represent
 
 These types are an alternative to using pointers, zero values, or similar null wrapper packages. Unlike similar solutions these will omit correctly from XML and JSON without the use of pointers and the compiler will ensure their value is not used when empty.
 
-Examples
+# Examples
 
 Wrap a pointer in an optional:
 
@@ -46,6 +46,5 @@ XML and JSON are supported out of the box. Use `omitempty` to omit the field whe
 	output, _ := json.Marshal(s)
 
 	// output = {"int2":1000}
-
 */
 package optional

--- a/example_test.go
+++ b/example_test.go
@@ -416,7 +416,7 @@ func Example_jsonUnmarshalPresent() {
 
 func Example_xmlMarshalOmitEmpty() {
 	s := struct {
-		XMLName xml.Name                      `xml:"s"`
+		XMLName xml.Name                     `xml:"s"`
 		Bool    optional.Optional[bool]      `xml:"bool,omitempty"`
 		Byte    optional.Optional[byte]      `xml:"byte,omitempty"`
 		Float32 optional.Optional[float32]   `xml:"float32,omitempty"`
@@ -461,7 +461,7 @@ func Example_xmlMarshalOmitEmpty() {
 
 func Example_xmlMarshalEmpty() {
 	s := struct {
-		XMLName xml.Name         `xml:"s"`
+		XMLName xml.Name                     `xml:"s"`
 		Bool    optional.Optional[bool]      `xml:"bool"`
 		Byte    optional.Optional[byte]      `xml:"byte"`
 		Float32 optional.Optional[float32]   `xml:"float32"`
@@ -523,7 +523,7 @@ func Example_xmlMarshalEmpty() {
 
 func Example_xmlMarshalPresent() {
 	s := struct {
-		XMLName xml.Name         `xml:"s"`
+		XMLName xml.Name                     `xml:"s"`
 		Bool    optional.Optional[bool]      `xml:"bool"`
 		Byte    optional.Optional[byte]      `xml:"byte"`
 		Float32 optional.Optional[float32]   `xml:"float32"`
@@ -585,7 +585,7 @@ func Example_xmlMarshalPresent() {
 
 func Example_xmlUnmarshalEmpty() {
 	s := struct {
-		XMLName xml.Name         `xml:"s"`
+		XMLName xml.Name                     `xml:"s"`
 		Bool    optional.Optional[bool]      `xml:"bool"`
 		Byte    optional.Optional[byte]      `xml:"byte"`
 		Float32 optional.Optional[float32]   `xml:"float32"`
@@ -646,7 +646,7 @@ func Example_xmlUnmarshalEmpty() {
 
 func Example_xmlUnmarshalPresent() {
 	s := struct {
-		XMLName xml.Name         `xml:"s"`
+		XMLName xml.Name                     `xml:"s"`
 		Bool    optional.Optional[bool]      `xml:"bool"`
 		Byte    optional.Optional[byte]      `xml:"byte"`
 		Float32 optional.Optional[float32]   `xml:"float32"`


### PR DESCRIPTION
### What
Run go fmt with Go 1.21rc2

### Why
Keep the code formatted.