### PR TITLE
Improve examples in docs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -5,7 +5,16 @@ These types are an alternative to using pointers, zero values, or similar null w
 
 Examples
 
-Wrap a pointer in an optional:
+Wrap a value in an optional:
+
+	var i int = ...
+	o := optional.Of(i)
+
+Or, create a none optional:
+
+	o := optional.None[int]()
+
+Or, wrap a pointer in an optional:
 
 	var i *int = ...
 	o := optional.OfPtr(i)


### PR DESCRIPTION
### What
Improve examples in docs

### Why
The examples lead with a pointer value, but I think creating optioanl values of non-pointers is more common.