### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,23 +1,21 @@
 name: go
 on:
-  schedule:
-      - cron:  '0 0 * * 0' # every 7 days on Sunday
   push:
   pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.18
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1
       - run: go build ./...
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.18
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1
       - run: go test -race -cover ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 1
-      - run: go build ./...
+      - run: go build
   test:
     runs-on: ubuntu-latest
     steps:
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 1
-      - run: go test -race -cover ./...
+      - run: go test -race -cover

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,8 @@
 name: go
 on:
   push:
+    branches:
+    - main
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
### What
Remove the schedule, checkout before setup-go, use the new setup-go, use latest go version.

### Why
Get tests running on latest Go and general clean up.