### PR TITLE
Fix example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -10,9 +10,9 @@ Wrap a value in an optional:
 	var i int = ...
 	o := optional.Of(i)
 
-Or, create a none optional:
+Or, create an empty optional:
 
-	o := optional.None[int]()
+	o := optional.Empty[int]()
 
 Or, wrap a pointer in an optional:
 


### PR DESCRIPTION
### What
Change the 'None' in the doc examples to 'Empty'.

### Why
That's what the function is called. I've been coding in Rust too long and wrote 'None' in the docs.